### PR TITLE
fix: configure npm Trusted Publishers for GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,6 @@ jobs:
         with:
           node-version: 22.21.0
           cache: "pnpm"
-          registry-url: "https://registry.npmjs.org"
 
       - name: "Install Dependencies"
         run: pnpm install
@@ -88,5 +87,3 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Remove NPM_TOKEN secret usage in favor of OIDC authentication:
- Remove registry-url from Node.js setup
- Remove NODE_AUTH_TOKEN and NPM_TOKEN environment variables
- Rely on existing id-token: write permission for OIDC

This requires configuring Trusted Publishers on npm.com before use.
